### PR TITLE
fix firetouchinterest logic n ship it

### DIFF
--- a/module/internal/env/libs/signals.hpp
+++ b/module/internal/env/libs/signals.hpp
@@ -576,6 +576,13 @@ namespace Interactions
         lua_call(L, 2, 1);
     }
 
+    void checkIsA(lua_State* L, int idx, const char* idk) {
+        lua_getfield(L, idx, "IsA");
+        lua_pushvalue(L, idx);
+        lua_pushstring(L, idk);
+        lua_call(L, 2, 1);
+    }
+
     int firetouchinterest(lua_State* L)
     {
         luaL_checktype(L, 1, LUA_TUSERDATA);
@@ -588,11 +595,11 @@ namespace Interactions
         if (std::string(luaL_typename(L, 2)) != "Instance")
             luaL_typeerror(L, 2, "Instance");
 
-        checkIsA(L, "BasePart");
+        checkIsA(L, 1, "BasePart");
         const bool bp_1 = lua_toboolean(L, -1);
         lua_pop(L, 1);
 
-        checkIsA(L, "BasePart");
+        checkIsA(L, 2, "BasePart");
         const bool bp_2 = lua_toboolean(L, -1);
         lua_pop(L, 1);
 
@@ -608,12 +615,13 @@ namespace Interactions
         const uintptr_t Overlap1 = *reinterpret_cast<uintptr_t*>(Primitive1 + Offsets::Instance::Overlap);
         const uintptr_t Overlap2 = *reinterpret_cast<uintptr_t*>(Primitive2 + Offsets::Instance::Overlap);
 
-        if (Overlap1 != Overlap2 || !Primitive1 || !Primitive2)
+        if (!Primitive1 || !Primitive2 || !Overlap1 || !Overlap2)
             luaL_error(L, ("lmk if this happens it shouldnt."));
 
-        const int Fire = lua_isboolean(L, 3) ? lua_toboolean(L, 3) : lua_tointeger(L, 3);
+        const int toggle = lua_isboolean(L, 3) ? (lua_toboolean(L, 3) ? 0 : 1) : lua_tointeger(L, 3);
+        const bool fire = toggle == 0;
 
-        Roblox::FireTouchInterest(Overlap2, Primitive1, Primitive2, Fire, 1);
+        Roblox::FireTouchInterest(Overlap2, Primitive1, Primitive2, fire, 1);
         return 0;
     }
 
@@ -878,7 +886,7 @@ namespace Interactions
 
         Utils::AddFunction(L, "fireproximityprompt", fireproximityprompt);
         Utils::AddFunction(L, "fireclickdetector", fireclickdetector);
-        //Utils::AddFunction(L, "firetouchinterest", firetouchinterest);
+        Utils::AddFunction(L, "firetouchinterest", firetouchinterest);
 
         Utils::AddFunction(L, "getconnections", getconnections);
 


### PR DESCRIPTION
### Motivation
- Fix incorrect argument validation, toggle handling, and registration for the `firetouchinterest` helper so it behaves according to docs and is exposed to scripts.

### Description
- Add an overloaded `checkIsA` that accepts an index and update `firetouchinterest` to call `checkIsA(L, 1, "BasePart")` and `checkIsA(L, 2, "BasePart")` so both instances are validated as `BasePart`.
- Change the overlap/primitive guard to `if (!Primitive1 || !Primitive2 || !Overlap1 || !Overlap2)` to avoid rejecting valid distinct parts.
- Normalize the boolean/number toggle into `toggle` and `fire` where `true`/`0` means touch and `false`/`1` means un-touch, and pass the boolean `fire` into `Roblox::FireTouchInterest`.
- Uncomment the registration so `firetouchinterest` is exposed via `RegisterLibrary` with `Utils::AddFunction`.

### Testing
- Ran `git diff --check` which succeeded.
- Ran `rg -n "firetouchinterest" module/internal/env/libs/signals.hpp` which confirmed the function and registration are present

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699d3d3602748321b890fdf0acc0eae5)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix firetouchinterest so it matches docs and can be used from scripts.

- **Bug Fixes**
  - Added indexed checkIsA and validate args 1 and 2 as BasePart.
  - Updated guard to fail on null primitives/overlaps instead of rejecting distinct parts.
  - Normalized toggle: true/0 = touch, false/1 = un-touch; pass boolean to Roblox::FireTouchInterest.
  - Registered firetouchinterest via RegisterLibrary (Utils::AddFunction).

<sup>Written for commit bd9d1b08fffbe3a53b8e6c93c4c392bf2fac605c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

